### PR TITLE
update postgres and timescale version and set pg_prometheus version in control file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM postgres:10.2-alpine
+FROM postgres:10.4-alpine
 
 MAINTAINER erik@timescale.com
 
-ENV PG_MAJOR 10.2
-ENV TIMESCALEDB_VERSION 0.9.1
-ENV PG_PROMETHEUS_VERSION 0.0.1
+ENV PG_MAJOR 10.4
+ENV TIMESCALEDB_VERSION 0.11.0
+ENV PG_PROMETHEUS_VERSION 0.2
 
 COPY pg_prometheus.control Makefile /build/pg_prometheus/
 COPY src/*.c src/*.h /build/pg_prometheus/src/
@@ -29,6 +29,7 @@ RUN set -ex \
     \
     && cd /build/timescaledb-${TIMESCALEDB_VERSION} && ./bootstrap && cd build && make install \
     \
+    && sed -i "s/default_version = '[0-9.]\+'/default_version = '${PG_PROMETHEUS_VERSION}'/" /build/pg_prometheus/pg_prometheus.control \
     && make -C /build/pg_prometheus install \
     \
     && apk del .fetch-deps .build-deps \


### PR DESCRIPTION
This PR changes the Dockerfile to use postgres 10.4 and timescale 0.10.0. It also uses PG_PROMETHEUS_VERSION and sets it in the control file