### PR TITLE
Don't disable postgres password authentication when POSTGRES_PASSWORD is not set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV PG_PROMETHEUS_VERSION 0.0.1
 COPY pg_prometheus.control Makefile /build/pg_prometheus/
 COPY src/*.c src/*.h /build/pg_prometheus/src/
 COPY sql/prometheus.sql /build/pg_prometheus/sql/
+COPY docker-entrypoint-initdb.d/reenable_auth.sh /docker-entrypoint-initdb.d/
 
 RUN set -ex \
     && apk add --no-cache --virtual .fetch-deps \

--- a/docker-entrypoint-initdb.d/reenable_auth.sh
+++ b/docker-entrypoint-initdb.d/reenable_auth.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# reenable password authentication
+sed -i "s/host all all all trust/host all all all md5/" /var/lib/postgresql/data/pg_hba.conf


### PR DESCRIPTION
When POSTGRES_PASSWORD is not set on the initial container
when initdb is run then the docker entrypoint of the postgres
container will disable password checks for everybody.
This change will overwrite that behaviour and keep password
checks intact.