### PR TITLE
Update Dockerfile to use latest stable version of TimescaleDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,13 @@
-FROM postgres:10.4-alpine
+ARG PG_VERSION_TAG
+FROM timescale/timescaledb:0.12.1-${PG_VERSION_TAG}
 
-MAINTAINER erik@timescale.com
-
-ENV PG_MAJOR 10.4
-ENV TIMESCALEDB_VERSION 0.11.0
+MAINTAINER Timescale https://www.timescale.com
 
 COPY pg_prometheus.control Makefile /build/pg_prometheus/
 COPY src/*.c src/*.h /build/pg_prometheus/src/
 COPY sql/prometheus.sql /build/pg_prometheus/sql/
 
 RUN set -ex \
-    && apk add --no-cache --virtual .fetch-deps \
-                ca-certificates \
-                openssl \
-                tar \
-                git \
-    && git clone https://github.com/timescale/timescaledb -b ${TIMESCALEDB_VERSION} /build/timescaledb-${TIMESCALEDB_VERSION} \
-    \
     && apk add --no-cache --virtual .build-deps \
                 coreutils \
                 dpkg-dev dpkg \
@@ -24,12 +15,8 @@ RUN set -ex \
                 libc-dev \
                 make \
                 util-linux-dev \
-                cmake \
-    \
-    && cd /build/timescaledb-${TIMESCALEDB_VERSION} && ./bootstrap && cd build && make install \
     \
     && make -C /build/pg_prometheus install \
     \
-    && apk del .fetch-deps .build-deps \
-    && rm -rf /build \
-    && sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'(.*)'/\1 = 'timescaledb,\2'/;s/,'/'/" /usr/local/share/postgresql/postgresql.conf.sample
+    && apk del .build-deps \
+    && rm -rf /build

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SQL_FILES = sql/prometheus.sql
 
 EXT_VERSION = $(shell cat pg_prometheus.control | grep 'default' | sed "s/^.*'\(.*\)'$\/\1/g")
 EXT_SQL_FILE = sql/$(EXTENSION)--$(EXT_VERSION).sql
+PG_VER=pg10
 
 DATA = $(EXT_SQL_FILE)
 MODULE_big = $(EXTENSION)
@@ -67,15 +68,12 @@ package: clean $(EXT_SQL_FILE)
 	$(install_sh) -m 644 $(EXT_SQL_FILE) 'package/extension/'
 
 docker-image: Dockerfile
-	docker build -t $(ORGANIZATION)/$(DOCKER_IMAGE_NAME) .
+	docker build --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORGANIZATION)/$(DOCKER_IMAGE_NAME) .
 	docker tag $(ORGANIZATION)/$(EXTENSION):latest $(ORGANIZATION)/$(EXTENSION):${GIT_VERSION}
-	docker tag $(ORGANIZATION)/$(EXTENSION):latest $(ORGANIZATION)/$(EXTENSION):${GIT_BRANCH}
 	docker tag $(ORGANIZATION)/$(EXTENSION):latest $(ORGANIZATION)/$(EXTENSION):${EXT_VERSION}
 
 docker-push: docker-image
 	docker push $(ORGANIZATION)/$(EXTENSION):latest
-	docker push $(ORGANIZATION)/$(EXTENSION):${GIT_VERSION}
-	docker push $(ORGANIZATION)/$(EXTENSION):${GIT_BRANCH}
 	docker push $(ORGANIZATION)/$(EXTENSION):${EXT_VERSION}
 
 typedef.list: clean $(OBJS)


### PR DESCRIPTION
Instead of having pg_prometheus and the main TimescaleDB image
potentially getting out of sync when it comes to building, we now
base this Docker image on the main TimescaleDB image. We can
therefore remove a lot of build cruft as well.