### PR TITLE
Adds CMD override as per README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,5 @@ RUN set -ex \
     \
     && apk del .build-deps \
     && rm -rf /build
+
+CMD postgres -csynchronous_commit=off


### PR DESCRIPTION
In the README, the command is specified as `postgres -csynchronous_commit=off`, but the command inherited from the postgres image is just `postgres`.

At the moment, we're running timescaledb in kubernetes using the [postgresql helm chart](https://github.com/helm/charts/tree/master/stable/postgresql) with the following value overrides:
```
image: "timescale/pg_prometheus"
imageTag: "0.2.1"
```

However, the helm chart doesn't provide a way to override the entry command. Since this is in the README (as well as the prometheus-postgresql-adapter README), it makes sense to explicitly add this to docker image to minimise friction for others who want to use the helm chart directly.