### PR TITLE
Use the P macro convention for jsonb

### DIFF
--- a/src/prom.c
+++ b/src/prom.c
@@ -404,7 +404,12 @@ prom_construct(PG_FUNCTION_ARGS)
 	TimestampTz ts = PG_GETARG_TIMESTAMPTZ(0);
 	text	   *name = PG_GETARG_TEXT_PP(1);
 	float8		value = PG_GETARG_FLOAT8(2);
-	Jsonb	   *jb = PG_GETARG_JSONB(3);
+	
+	#ifdef PG_GETARG_JSONB_P
+		Jsonb	   *jb = PG_GETARG_JSONB_P(3);
+	#else
+		Jsonb	   *jb = PG_GETARG_JSONB(3);
+	#endif
 
 	char	   *metric_name = text_to_cstring(name);
 	PrometheusJsonbParseCtx ctx = {0};


### PR DESCRIPTION
The project naming convention has changed to use P when dealing with a pointer. Therefore the plugin will not build/install on newer versions of Postgres due to this.  More details are available here: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=4bd1994650fddf49e717e35f1930d62208845974 .

If there are any modifications needed, please let me know. Thank you!