### PR TITLE
Update Dockerfile TimescaleDB ver and make it an ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG PG_VERSION_TAG
-FROM timescale/timescaledb:1.4.0-${PG_VERSION_TAG}
+ARG PG_VERSION_TAG=pg11
+ARG TIMESCALEDB_VERSION=1.4.2
+FROM timescale/timescaledb:${TIMESCALEDB_VERSION}-${PG_VERSION_TAG}
 
 MAINTAINER Timescale https://www.timescale.com
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SQL_FILES = sql/prometheus.sql
 
 EXT_VERSION = $(shell cat pg_prometheus.control | grep 'default' | sed "s/^.*'\(.*\)'$\/\1/g")
 EXT_SQL_FILE = sql/$(EXTENSION)--$(EXT_VERSION).sql
-PG_VER=pg10
+PG_VER=pg11
 
 DATA = $(EXT_SQL_FILE)
 MODULE_big = $(EXTENSION)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SQL_FILES = sql/prometheus.sql
 EXT_VERSION = $(shell cat pg_prometheus.control | grep 'default' | sed "s/^.*'\(.*\)'$\/\1/g")
 EXT_SQL_FILE = sql/$(EXTENSION)--$(EXT_VERSION).sql
 PG_VER=pg11
+TIMESCALEDB_VER=1.4.1
 
 DATA = $(EXT_SQL_FILE)
 MODULE_big = $(EXTENSION)
@@ -68,13 +69,13 @@ package: clean $(EXT_SQL_FILE)
 	$(install_sh) -m 644 $(EXT_SQL_FILE) 'package/extension/'
 
 docker-image: Dockerfile
-	docker build --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORGANIZATION)/$(DOCKER_IMAGE_NAME) .
-	docker tag $(ORGANIZATION)/$(EXTENSION):latest $(ORGANIZATION)/$(EXTENSION):${GIT_VERSION}
-	docker tag $(ORGANIZATION)/$(EXTENSION):latest $(ORGANIZATION)/$(EXTENSION):${EXT_VERSION}
+	docker build --build-arg TIMESCALEDB_VERSION=$(TIMESCALEDB_VER) --build-arg PG_VERSION_TAG=$(PG_VER) -t $(ORGANIZATION)/$(DOCKER_IMAGE_NAME):latest-$(PG_VER) .
+	docker tag $(ORGANIZATION)/$(EXTENSION):latest-$(PG_VER) $(ORGANIZATION)/$(EXTENSION):${GIT_VERSION}-$(PG_VER)
+	docker tag $(ORGANIZATION)/$(EXTENSION):latest-$(PG_VER) $(ORGANIZATION)/$(EXTENSION):${EXT_VERSION}-$(PG_VER)
 
 docker-push: docker-image
-	docker push $(ORGANIZATION)/$(EXTENSION):latest
-	docker push $(ORGANIZATION)/$(EXTENSION):${EXT_VERSION}
+	docker push $(ORGANIZATION)/$(EXTENSION):latest-$(PG_VER)
+	docker push $(ORGANIZATION)/$(EXTENSION):${EXT_VERSION}-$(PG_VER)
 
 typedef.list: clean $(OBJS)
 	./scripts/generate_typedef.sh

--- a/pg_prometheus.control
+++ b/pg_prometheus.control
@@ -1,5 +1,5 @@
 # pg_prometheus extension
 comment = 'Prometheus metrics for PostgreSQL'
-default_version = '0.2.1'
+default_version = '0.2.2'
 module_pathname = '$libdir/pg_prometheus'
 relocatable = true


### PR DESCRIPTION
The TIMESCALEDB_VERSION arg in the dockerfile
should make it easier to build images with newer
TimescaleDB versions if we take a while to publish
a pre-built one