### PR TITLE
fixing Docker build -t fails due to missing build requs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN set -ex \
                 libc-dev \
                 make \
                 util-linux-dev \
+		clang \
+		llvm \
     \
     && make -C /build/pg_prometheus install \
     \


### PR DESCRIPTION
building pg_prometheus requires clang and llvm. Updated Dockerfile to install them.