### PR TITLE
Fix bug when labels include "\" character before closing quotes

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -77,7 +77,7 @@ parse_labels(char *input, PrometheusParseCtx *ctx)
 
 		value_start = input + i;
 
-		while ((input[i] != '"' || (input[i] == '"' && input[i-1] =='\\')) && input[i] != '\0')
+		while ((input[i] != '"' || (input[i] == '"' && input[i-1] =='\\'  && input[i-2] !='\\')) && input[i] != '\0')
 		{
 			i++;
 		}


### PR DESCRIPTION
Fix bug when labels include "\" character before closing quotes

Input example:
vmware_vm_guest_disk_capacity{cluster_name="CLUSTER-ABC",dc_name="LAN-BRAZIL",environment="Datacenter-AWS",host_name="lan.example.com",instance="localhost:9273",job="vmware_exporter",partition="F:\\",vm_name="VMTEST001"} 21064335360 1592592551506

Error Output: Unexpected end char V
In this case the value of partition label is parsed as "F:\\",vm_name=".  